### PR TITLE
Add bike rental skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# Bike Rental Example
+
+This is a simple Next.js example demonstrating a bike rental area with admin and user pages. It provides placeholder components to showcase how a bike rental app could be structured.
+
+## Routes
+
+- `/bike-rental` – lists bikes that can be rented.
+- `/bike-rental/user` – shows a user dashboard.
+- `/bike-rental/admin` – shows an admin dashboard.
+
+These pages use static data and are intended as a starting point for a more full‑featured application.

--- a/app/bike-rental/admin/page.tsx
+++ b/app/bike-rental/admin/page.tsx
@@ -1,0 +1,8 @@
+export default function BikeAdminPage() {
+  return (
+    <div className="space-y-4">
+      <h2 className="text-2xl font-semibold">Admin Dashboard</h2>
+      <p className="text-muted-foreground">Manage bikes, rentals and users.</p>
+    </div>
+  );
+}

--- a/app/bike-rental/layout.tsx
+++ b/app/bike-rental/layout.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from 'next';
+import { ReactNode } from 'react';
+
+export const metadata: Metadata = {
+  title: 'Bike Rental',
+};
+
+export default function BikeRentalLayout({ children }: { children: ReactNode }) {
+  return (
+    <div className="container mx-auto px-4 py-12">
+      <h1 className="text-3xl md:text-4xl font-bold mb-6">Bike Rental</h1>
+      {children}
+    </div>
+  );
+}

--- a/app/bike-rental/page.tsx
+++ b/app/bike-rental/page.tsx
@@ -1,0 +1,31 @@
+import { Bike } from '@/lib/types';
+import { BikeCard } from '@/components/bike-card';
+
+const bikes: Bike[] = [
+  {
+    id: 1,
+    name: 'City Cruiser',
+    description: 'Comfortable bike for city rides.',
+    price_per_hour: 5,
+    available: true,
+    image_url: '/bike1.jpg',
+  },
+  {
+    id: 2,
+    name: 'Mountain Explorer',
+    description: 'Perfect for off-road adventures.',
+    price_per_hour: 8,
+    available: false,
+    image_url: '/bike2.jpg',
+  },
+];
+
+export default function BikesPage() {
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6">
+      {bikes.map((bike) => (
+        <BikeCard key={bike.id} bike={bike} />
+      ))}
+    </div>
+  );
+}

--- a/app/bike-rental/user/page.tsx
+++ b/app/bike-rental/user/page.tsx
@@ -1,0 +1,8 @@
+export default function BikeUserPage() {
+  return (
+    <div className="space-y-4">
+      <h2 className="text-2xl font-semibold">My Rentals</h2>
+      <p className="text-muted-foreground">View and manage your current and past rentals.</p>
+    </div>
+  );
+}

--- a/components/bike-card.tsx
+++ b/components/bike-card.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import Image from 'next/image';
+import { Bike } from '@/lib/types';
+import { Card } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+
+interface BikeCardProps {
+  bike: Bike;
+  onRent?: (bike: Bike) => void;
+}
+
+export function BikeCard({ bike, onRent }: BikeCardProps) {
+  return (
+    <Card className="p-4 flex flex-col items-center gap-4">
+      {bike.image_url && (
+        <Image
+          src={bike.image_url}
+          alt={bike.name}
+          width={200}
+          height={120}
+          className="object-cover rounded"
+        />
+      )}
+      <h3 className="text-lg font-semibold">{bike.name}</h3>
+      <p className="text-sm text-muted-foreground text-center line-clamp-2">
+        {bike.description}
+      </p>
+      <div className="mt-auto flex w-full justify-between items-center">
+        <span className="font-medium">${{bike.price_per_hour}}/hr</span>
+        <Button disabled={!bike.available} onClick={() => onRent?.(bike)}>
+          {bike.available ? 'Rent' : 'Unavailable'}
+        </Button>
+      </div>
+    </Card>
+  );
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -19,3 +19,12 @@ export interface Tool {
   created_at: string;
   updated_at: string;
 }
+
+export interface Bike {
+  id: number;
+  name: string;
+  image_url?: string;
+  description: string;
+  price_per_hour: number;
+  available: boolean;
+}


### PR DESCRIPTION
## Summary
- create a Bike type
- add a BikeCard component
- scaffold bike rental pages with admin and user sections
- document the example

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686259ebfa8c8320bf63eb63ced7ed7c